### PR TITLE
Use Github Actions native deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - main
 
-# Set permissions of GITHUB_TOKEN to allow deployment to pages
+# Set permissions of GITHUB_TOKEN to allow deployment to gh-pages
 permissions:
   pages: write
   id-token: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Create deployment artifact
       uses: actions/upload-pages-artifact@v1
       with:
-        path: gh-pages
+        path: sitio/_build/html
 
   deploy:
     environment:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,14 +9,26 @@ on:
     branches:
       - main
 
+# Set permissions of GITHUB_TOKEN to allow deployment to pages
+permissions:
+  pages: write
+  id-token: write
+  contents: read
+  
+# Only allow one deployment at a time
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
 # This job installs dependencies, builds the book, and pushes it to gh-pages
 jobs:
-  build-and-deploy-book:
+  build-book:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
         python-version: [3.8]
+    
     steps:
     - uses: actions/checkout@v2
 
@@ -33,11 +45,20 @@ jobs:
     - name: Build the book
       run: |
         jupyter-book build sitio
-
-    # Deploy the book's HTML to gh-pages branch
-    - name: GitHub Pages action
-      uses: peaceiris/actions-gh-pages@v3.6.1
+        
+    - name: Create deployment artifact
+      uses: actions/upload-pages-artifact@v1
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: sitio/_build/html
-        publish_branch: gh-pages
+        path: gh-pages
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: unbuntu-latest
+    needs: build-book
+    if: github.ref == 'refs/heads/main' && github.repository == 'Intercoonecta/Intercoonecta.github.io'
+    steps:
+      - name: Deploy to Github Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: unbuntu-latest
+    runs-on: ubuntu-latest
     needs: build-book
     if: github.ref == 'refs/heads/main' && github.repository == 'Intercoonecta/Intercoonecta.github.io'
     steps:


### PR DESCRIPTION
@emiliom Pages is now more natively integrated into Actions, so this is set up to use the native actions rather than third party ones.

https://github.blog/changelog/2022-07-27-github-pages-custom-github-actions-workflows-beta/