### PR TITLE
Mover tutoriales de aula invertida y ohw22-es a nueva seccion 

### DIFF
--- a/sitio/_toc.yml
+++ b/sitio/_toc.yml
@@ -27,6 +27,16 @@ parts:
   - file: primeros-pasos
     title: Primeros pasos
   - file: tutoriales
+- caption: Proyectos
+  chapters:
+  - file: proyectos/index
+    title: Descripción
+  - file: proyectos/proyectos
+    title: Lista de proyectos
+  - file: proyectos/nuevoproyecto
+    title: Sugerir proyectos
+- caption: Otros Tutoriales
+  chapters:
   - file: aulainvertida
     sections:
     - url: https://github.com/Intercoonecta/Aula-invertida/blob/main/Intro-a-github/Github.md
@@ -46,14 +56,6 @@ parts:
       title: Redes espaciales, R
     - url: https://github.com/oceanhackweek/ohw-tutorials/tree/OHW22/optional/espanol/lme-obis-extracciones
       title: Biodiversidad marina, R
-- caption: Proyectos
-  chapters:
-  - file: proyectos/index
-    title: Descripción
-  - file: proyectos/proyectos
-    title: Lista de proyectos
-  - file: proyectos/nuevoproyecto
-    title: Sugerir proyectos
 - caption: Recursos
   chapters:
   - file: jupyter_y_python


### PR DESCRIPTION
Nueva seccion de Otros Tutoriales, para minimizar confusión con los tutoriales que se darán en el hackatón.

@marianpena que te parece este cambio? Los tutoriales del Aula Invertida y OHW22 es ahora están en otra sección. Podés ver el preview aquí: https://deploy-preview-13--sage-puppy-e64764.netlify.app/