### PR TITLE
Update external actions in deploy.yml to current versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,14 +27,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8]
+        python-version: [3.11]
     
     steps:
     - uses: actions/checkout@v2
 
     # Install dependencies
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
         jupyter-book build sitio
         
     - name: Create deployment artifact
-      uses: actions/upload-pages-artifact@v1
+      uses: actions/upload-pages-artifact@v3
       with:
         path: sitio/_build/html
 
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to Github Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Update `python-version` to 3.11, and the following GitHub actions:
- setup-python to v5
- upload-pages-artifact to v3
- deploy-pages to v4

These updates addresses recent build errors.