### PR TITLE
Actualizar enlaces a tutoriales de hackatones 2023 y 2024

### DIFF
--- a/sitio/_toc.yml
+++ b/sitio/_toc.yml
@@ -58,23 +58,23 @@ parts:
   - file: ohw2023
     title: OHWe 2023 
     sections:
-    - url: https://github.com/Intercoonecta/tutoriales/tree/main/lunes/Ciencia_abierta/
+    - url: https://github.com/Intercoonecta/tutoriales/tree/ohwe23/lunes/Ciencia_abierta/
       title: Ciencia abierta
-    - url: https://github.com/Intercoonecta/tutoriales/tree/main/lunes/Datos_online/
+    - url: https://github.com/Intercoonecta/tutoriales/tree/ohwe23/lunes/Datos_online/
       title: Datos online
-    - url: https://github.com/Intercoonecta/tutoriales/tree/main/lunes/Visualizacion_en_R/
+    - url: https://github.com/Intercoonecta/tutoriales/tree/ohwe23/lunes/Visualizacion_en_R/
       title: Visualización en R
-    - url: https://github.com/Intercoonecta/tutoriales/tree/main/martes/Dia2_Datos_espaciales_R/
+    - url: https://github.com/Intercoonecta/tutoriales/tree/ohwe23/martes/Dia2_Datos_espaciales_R/
       title: Datos espaciales en R
-    - url: https://github.com/Intercoonecta/tutoriales/tree/main/miercoles/Dia3_Datos_temporales_R/
+    - url: https://github.com/Intercoonecta/tutoriales/tree/ohwe23/miercoles/Dia3_Datos_temporales_R/
       title: Datos temporales en R
-    - url: https://github.com/Intercoonecta/tutoriales/tree/main/martes/visualizacion_python/
+    - url: https://github.com/Intercoonecta/tutoriales/tree/ohwe23/martes/visualizacion_python/
       title: Visualización en Python
-    - url: https://github.com/Intercoonecta/tutoriales/tree/main/martes/datos_espaciales_python/
+    - url: https://github.com/Intercoonecta/tutoriales/tree/ohwe23/martes/datos_espaciales_python/
       title: Datos espaciales en Python
-    - url: https://github.com/Intercoonecta/tutoriales/tree/main/martes/El_paquete_echogram_R/
+    - url: https://github.com/Intercoonecta/tutoriales/tree/ohwe23/martes/El_paquete_echogram_R/
       title: Acústica - ecosondas, R
-    - url: https://github.com/Intercoonecta/tutoriales/tree/main/miercoles/acustica_python/
+    - url: https://github.com/Intercoonecta/tutoriales/tree/ohwe23/miercoles/acustica_python/
       title: Acústica - ecosondas, Python
   - file: ohw22-espanol
     title: OHW 2022

--- a/sitio/ohw2023.md
+++ b/sitio/ohw2023.md
@@ -4,7 +4,9 @@ El hackatón 2023 toma lugar del **lunes 27 de febrero al viernes 3 de marzo, 20
 
 Las horas incluidas en el programa son en horario de [Guatemala, UTC-6](https://www.zeitverschiebung.net/es/city/3598132)
 
-Todos los materiales de los tutoriales se encuentran en el repositorio https://github.com/Intercoonecta/tutoriales/
+Todos los materiales de los tutoriales se alojan en el repositorio [https://github.com/Intercoonecta/tutoriales](https://github.com/Intercoonecta/tutoriales)
+
+
 ## Viernes 24 de febrero
 
 | Hora |	Evento | 
@@ -17,11 +19,11 @@ Todos los materiales de los tutoriales se encuentran en el repositorio https://g
 | Hora |	Charla |	Presentador/a | 
 | ------------- |-------- | ------------- |
 |08:00-08:15|	Bienvenida|	Marian| 
-|08:15-09:00| [Reproducibilidad y ciencia abierta](https://github.com/Intercoonecta/tutoriales/blob/main/martes/Ciencia_abierta/Ciencia_abierta.pdf) ([video](https://youtu.be/NYAq1xrc8Zc)) |	Laura |
+|08:15-09:00| [Reproducibilidad y ciencia abierta](https://github.com/Intercoonecta/tutoriales/tree/ohwe23/lunes/Ciencia_abierta) ([video](https://youtu.be/NYAq1xrc8Zc)) |	Laura |
 |09:00-09:15| Entrada a Jupyter Hub en Python ([video](https://youtu.be/DJV7gOUVGDc)) |	Emilio|
-|09:15-10:00|	[Datos online](https://github.com/Intercoonecta/tutoriales/blob/main/lunes/Datos_online/datos_online.ipynb) ([video](https://youtu.be/Qbn_Y4sm4Oc)) |	Laura| 
+|09:15-10:00|	[Datos online](https://github.com/Intercoonecta/tutoriales/tree/ohwe23/lunes/Datos_online) ([video](https://youtu.be/Qbn_Y4sm4Oc)) |	Laura| 
 |10:00-10:05| Entrada a Jupyter Hub en R ([video](https://youtu.be/DJV7gOUVGDc)) | Emilio	|
-|10:05-10:50|	[Visualización en R](https://github.com/Intercoonecta/tutoriales/blob/main/lunes/Visualizacion_en_R/Visualizacion_en_R.md) ([video](https://youtu.be/20Gjx1-0D0Y))	|Héctor|
+|10:05-10:50|	[Visualización en R](https://github.com/Intercoonecta/tutoriales/tree/ohwe23/lunes/Visualizacion_en_R) ([video](https://youtu.be/20Gjx1-0D0Y))	|Héctor|
 |10:50-11:20|	Proyectos y grupos ([video](https://youtu.be/GQpnUxn_Ah8)) |Todos|
 |11:30-13:30| **Trabajo en grupo Proyectos A**| |
 |15:00-17:00| **Trabajo en grupo Proyectos B**| |
@@ -32,21 +34,20 @@ Todos los materiales de los tutoriales se encuentran en el repositorio https://g
 |Hora|	Charla|	Presentador/a|
 | ------------- |-------- | ------------- |
 |08:00-08:15|	Bienvenida|	Marian|
-|08:15-09:00|	[Datos espaciales en R](https://github.com/Intercoonecta/tutoriales/blob/main/martes/Dia2_Datos_espaciales_R/Dia2_Datos_espaciales_R.md) ([vídeo](https://youtu.be/8DEZHXv15XQ)) |	Denisse |
-|09:00-09:45|	[Paquete echogram en R](https://github.com/Intercoonecta/tutoriales/blob/main/martes/El_paquete_echogram_R/echogramR.md) ([vídeo](https://youtu.be/wMR-XZvyFAU)) | 	Héctor |
-|09:45-10:30|	[Visualización en Python](https://github.com/Intercoonecta/tutoriales/blob/main/martes/Dia2_Visualizacion_Python.pdf) ([vídeo](https://youtu.be/fWtGZ0w6j48)) |	David |
-|10:30-11:15|		[Datos espaciales en Python](https://github.com/Intercoonecta/tutoriales/blob/main/martes/datos_espaciales_python) ([vídeo](https://youtu.be/IP0sGy8JxRQ)) | 	Emilio |
+|08:15-09:00|	[Datos espaciales en R](https://github.com/Intercoonecta/tutoriales/tree/ohwe23/martes/Dia2_Datos_espaciales_R) ([vídeo](https://youtu.be/8DEZHXv15XQ)) |	Denisse |
+|09:00-09:45|	[Paquete echogram en R](https://github.com/Intercoonecta/tutoriales/tree/ohwe23/martes/El_paquete_echogram_R) ([vídeo](https://youtu.be/wMR-XZvyFAU)) | 	Héctor |
+|09:45-10:30|	[Visualización en Python](https://github.com/Intercoonecta/tutoriales/tree/ohwe23/martes/visualizacion_python) ([vídeo](https://youtu.be/fWtGZ0w6j48)) |	David |
+|10:30-11:15|		[Datos espaciales en Python](https://github.com/Intercoonecta/tutoriales/tree/ohwe23/martes/datos_espaciales_python) ([vídeo](https://youtu.be/IP0sGy8JxRQ)) | 	Emilio |
 |11:15-13:15| **Trabajo en grupo Proyectos A**| |
 |15:00-17:00| **Trabajo en grupo Proyectos B**| |
-
 
 ## Miércoles 1 de marzo
 
 |Hora|	Charla|	Presentador/a|
 | ------------- |-------- | ------------- |
 |08:00-08:15|	Bienvenida|	Marian|
-|08:15-09:15|	[Datos temporales en R](https://github.com/Intercoonecta/tutoriales/blob/main/miercoles/Dia3_Datos_temporales_R/Dia3_Datos_temporales_R.md) ([vídeo](https://youtu.be/I9-e98f5N0M)) |	Denisse |
-|09:15-10:30|	[Echopype](https://github.com/Intercoonecta/tutoriales/blob/main/miercoles/acustica_python/echopype_procesamiento_ecosonar.ipynb) ([video](https://youtu.be/x4t1GpYCPcA)) | 	Emilio |
+|08:15-09:15|	[Datos temporales en R](https://github.com/Intercoonecta/tutoriales/tree/ohwe23/miercoles/Dia3_Datos_temporales_R) ([vídeo](https://youtu.be/I9-e98f5N0M)) |	Denisse |
+|09:15-10:30|	[Echopype](https://github.com/Intercoonecta/tutoriales/tree/ohwe23/miercoles/acustica_python) ([video](https://youtu.be/x4t1GpYCPcA)) | 	Emilio |
 |10:30-11:00| Datos temporales en Python y repositorios ([video](https://youtu.be/Cmx4y8J6Dlc)) | 	Emilio y Marian |
 |11:00-11:30| Revisión de proyectos ([video](https://youtu.be/mBrIKHw5twA)) | 	Marian y Emilio |
 |11:00-13:00| **Trabajo en grupo Proyectos A** | |

--- a/sitio/ohw2024.md
+++ b/sitio/ohw2024.md
@@ -4,7 +4,7 @@ El hackatón 2024 tendrá lugar del **lunes 25 de noviembre al viernes 29 de nov
 
 Las horas incluidas en el programa son en horario de [Guatemala, UTC-6](https://www.zeitverschiebung.net/es/city/3598132)
 
-Todos los materiales de los tutoriales se alojan en el repositorio [https://github.com/Intercoonecta/tutorialesOHW2024](https://github.com/Intercoonecta/tutorialesOHW2024/tree/main)
+Todos los materiales de los tutoriales se alojan en el repositorio [https://github.com/Intercoonecta/tutoriales](https://github.com/Intercoonecta/tutoriales)
 
 
 ## Lunes 25 de noviembre
@@ -12,8 +12,8 @@ Todos los materiales de los tutoriales se alojan en el repositorio [https://gith
 | Hora |	Charla |	Presentador/a | 
 | ------------- |-------- | ------------- |
 |08:00-08:15|	Bienvenida|	Marian| 
-|08:15-09:00| 	[Reproducibilidad y ciencia abierta](https://github.com/Intercoonecta/tutorialesOHW2024/tree/main/lunes/reproducibilidad_y_ciencia_abierta) - ([video](https://youtu.be/b5Ut6-ysKpA?t=2683)) |	Héctor | 
-|09:00-09:45|[Obtención de datos online](https://github.com/Intercoonecta/tutorialesOHW2024/tree/main/lunes/Julia) - ([video](https://youtu.be/b5Ut6-ysKpA?t=5324)) |	Julia|
+|08:15-09:00| 	[Reproducibilidad y ciencia abierta](https://github.com/Intercoonecta/tutoriales/tree/ohwe24/lunes/reproducibilidad_y_ciencia_abierta) - ([video](https://youtu.be/b5Ut6-ysKpA?t=2683)) |	Héctor | 
+|09:00-09:45|[Obtención de datos online](https://github.com/Intercoonecta/tutoriales/tree/ohwe24/lunes/Julia) - ([video](https://youtu.be/b5Ut6-ysKpA?t=5324)) |	Julia|
 |09:45-10:00|Descanso |	|
 |10:00-10:45| [Instalación de conda](https://github.com/Intercoonecta/Aula-invertida/blob/main/Intro-a-Jupyter/instalacion-jlab-conda.md) - ([video](https://youtu.be/b5Ut6-ysKpA?t=9217)) | Emilio	|
 |10:45-11:30|	Proyectos y grupos  |Todos|
@@ -26,8 +26,8 @@ Todos los materiales de los tutoriales se alojan en el repositorio [https://gith
 |Hora|	Charla|	Presentador/a|
 | ------------- |-------- | ------------- |
 |08:00-08:15|	Bienvenida|	Marian|
-|08:15-09:00| [Trabajando con datos de Global Fishing Watch](https://github.com/Intercoonecta/tutorialesOHW2024/tree/main/martes/Jorge) - ([video](https://youtu.be/B4xRUr8HMeA?t=197)) | 	Jorge |
-|09:00-09:45|	[Capturas de túnidos tropicales](https://github.com/Intercoonecta/tutorialesOHW2024/tree/main/martes/Marina%20-%20captura%20tu%CC%81nidos%20tropicales) - ([video](https://youtu.be/B4xRUr8HMeA?t=4104)) |	Marina |
+|08:15-09:00| [Trabajando con datos de Global Fishing Watch](https://github.com/Intercoonecta/tutoriales/tree/ohwe24/martes/Jorge) - ([video](https://youtu.be/B4xRUr8HMeA?t=197)) | 	Jorge |
+|09:00-09:45|	[Capturas de túnidos tropicales](https://github.com/Intercoonecta/tutoriales/tree/ohwe24/martes/Marina%20-%20captura%20tu%CC%81nidos%20tropicales) - ([video](https://youtu.be/B4xRUr8HMeA?t=4104)) |	Marina |
 |09:45-10:00|Descanso |	|
 |10:00-10:30| Revisión de proyectos  | Todos |
 |10:30-12:30| Trabajo en grupo Proyectos | |
@@ -38,10 +38,10 @@ Todos los materiales de los tutoriales se alojan en el repositorio [https://gith
 |Hora|	Charla|	Presentador/a|
 | ------------- |-------- | ------------- |
 |08:00-08:15|	Bienvenida|	Marian|
-|08:15-09:00|	[Datos de corrientes en Python](https://github.com/Intercoonecta/tutorialesOHW2024/tree/main/miercoles/eddy_tracking) - ([video](https://youtu.be/nOwlNlaQ48w?t=157)) | Charles |
-|09:00-09:45|	[Simulaciones de trayectorias de plásticos en Python](https://github.com/Intercoonecta/tutorialesOHW2024/tree/main/miercoles/simulaciones_trayectorias-plasticos) - ([video](https://youtu.be/nOwlNlaQ48w?t=2978)) |	Laura |
+|08:15-09:00|	[Datos de corrientes en Python](https://github.com/Intercoonecta/tutoriales/tree/ohwe24/miercoles/eddy_tracking) - ([video](https://youtu.be/nOwlNlaQ48w?t=157)) | Charles |
+|09:00-09:45|	[Simulaciones de trayectorias de plásticos en Python](https://github.com/Intercoonecta/tutoriales/tree/ohwe24/miercoles/simulaciones_trayectorias-plasticos) - ([video](https://youtu.be/nOwlNlaQ48w?t=2978)) |	Laura |
 |09:45-10:00| Descanso |	|
-|10:00-10:45|	[Datos de clima en Python](https://github.com/Intercoonecta/tutorialesOHW2024/tree/main/miercoles/datos_climaticos) - ([video](https://youtu.be/nOwlNlaQ48w?t=5558)) | Yeray	 |
+|10:00-10:45|	[Datos de clima en Python](https://github.com/Intercoonecta/tutoriales/tree/ohwe24/miercoles/datos_climaticos) - ([video](https://youtu.be/nOwlNlaQ48w?t=5558)) | Yeray	 |
 |11:00-13:00| Trabajo en grupo Proyectos | |
 
 


### PR DESCRIPTION
Después de consolidar estos tutoriales en branches en el repo "tutoriales"